### PR TITLE
Shift primitives correctness

### DIFF
--- a/theories/CodegenWasm/LambdaANF_to_Wasm_correct.v
+++ b/theories/CodegenWasm/LambdaANF_to_Wasm_correct.v
@@ -4971,7 +4971,6 @@ Proof.
         eassumption. } }
     - { (* lsl *)
         inv H2; simpl.
-        (* Opaque Uint63.to_Z. *)
         destruct (H3 (n1 << n2)%uint63) as [s' [s_final [fr [m' [wal [Hs' [Hstore [Hfr [Hsmem [Hstep [Hinv1 [Hupd_glob Hr]]]]]]]]]]]].
         replace v with (Vprim (primInt (n1 << n2)%uint63)) in * by congruence.
         exists s_final, fr.
@@ -5017,9 +5016,50 @@ Proof.
           dostep_nary_eliml 0 1. constructor; apply rs_label_const; auto.
           dostep_nary 2. eapply r_store_success.
           assert (to_Z 63 <= to_Z n2)%Z as Hle by now destruct (Z.lt_ge_cases (to_Z n2) (to_Z 63)).
-          rewrite (lsl_M_r _ _ Hle) in Hstore; eauto.
+          rewrite (uint63_lsl63 _ _ Hle) in Hstore; eauto.
           eassumption. } }
-    - { (* lsr *) admit. }
+    - { (* lsr *)
+        inv H2; simpl.
+        destruct (H3 (n1 >> n2)%uint63) as [s' [s_final [fr [m' [wal [Hs' [Hstore [Hfr [Hsmem [Hstep [Hinv1 [Hupd_glob Hr]]]]]]]]]]]].
+        replace v with (Vprim (primInt (n1 >> n2)%uint63)) in * by congruence.
+        exists s_final, fr.
+        split; auto.
+        dostep_nary 0. eapply r_global_get; eassumption.
+        eapply rt_trans.
+        apply app_trans_const; auto.
+        destruct (Z_lt_dec (to_Z n2) (to_Z 63)).
+        { (* n2 < 63 *)
+          dostep_nary_eliml 2 1. constructor; apply rs_relop.
+          dostep_nary_eliml 1 1. constructor; apply rs_if_true; unfold wasm_bool.
+          replace (Z_to_i64 63) with (Z_to_i64 (to_Z 63)) by now cbn.
+          rewrite uint63_lt_int64_lt; auto. discriminate.
+          dostep_nary_eliml 0 1. eapply r_block with (t1s:=[::]) (t2s:=[:: T_num T_i64])(vs:=[::]); auto.
+          eapply rt_trans.
+          separate_instr.
+          rewrite catA.
+          apply app_trans.
+          apply app_trans_const; auto.
+          eapply rt_trans.
+          eapply reduce_trans_label1.
+          apply HloadStep'.
+          eapply reduce_trans_label1.
+          apply rt_step. constructor; apply rs_binop_success. simpl.
+          rewrite uint63_lsr_i64_shr; simpl; auto.
+          dostep_nary_eliml 0 1. constructor; apply rs_label_const; auto.
+          dostep_nary 2. eapply r_store_success.
+          eassumption.
+          eassumption. }
+        { (* n2 <= 63 *)
+          dostep_nary_eliml 2 1. constructor; apply rs_relop.
+          dostep_nary_eliml 1 1. constructor; apply rs_if_false; unfold wasm_bool.
+          replace (Z_to_i64 63) with (Z_to_i64 (to_Z 63)) by now cbn.
+          rewrite uint63_nlt_int64_nlt; auto.
+          dostep_nary_eliml 0 1. eapply r_block with (t1s:=[::]) (t2s:=[:: T_num T_i64])(vs:=[::]); auto.
+          dostep_nary_eliml 0 1. constructor; apply rs_label_const; auto.
+          dostep_nary 2. eapply r_store_success.
+          assert (to_Z 63 <= to_Z n2)%Z as Hle by now destruct (Z.lt_ge_cases (to_Z n2) (to_Z 63)).
+          rewrite (uint63_lsr63 _ _ Hle) in Hstore; eauto.
+          eassumption. } }
     - (* land *) solve_arith_op_aux v (n1 land n2)%uint63 H2 H3 HloadStep' uint63_land_i64_and.
     - (* lor *) solve_arith_op_aux v (n1 lor n2)%uint63 H2 H3 HloadStep' uint63_lor_i64_or.
     - (* lxor *) solve_arith_op_aux v (n1 lxor n2)%uint63 H2 H3 HloadStep' uint63_lxor_i64_xor.

--- a/theories/CodegenWasm/LambdaANF_to_Wasm_primitives.v
+++ b/theories/CodegenWasm/LambdaANF_to_Wasm_primitives.v
@@ -918,9 +918,12 @@ Lemma uint63_lsl_i64_shl : forall x y,
     (to_Z y < to_Z 63)%Z -> Int64.iand (Int64.ishl (to_Z x) (to_Z y)) maxuint63 = to_Z (x << y).
 Proof.
   intros.
-  unfold Int64.ishl, Int64.shl.
-  repeat rewrite uint63_unsigned_id.
-  rewrite Z.shiftl_mul_pow2. 2: now assert (0 <= to_Z y < wB)%Z by apply to_Z_bounded.
+  have H' := to_Z_bounded y.
+  unfold Int64.ishl, Int64.shl, Int64.wordsize, Integers.Wordsize_64.wordsize.
+  replace (to_Z 63) with 63%Z in H by now cbn.
+  do 2 rewrite uint63_unsigned_id.
+  replace (Int64.unsigned (Z_to_i64 (to_Z y mod 64%nat))) with (to_Z y). 2: now rewrite Z.mod_small; [rewrite uint63_unsigned_id|].
+  rewrite Z.shiftl_mul_pow2. 2: lia.
   now rewrite lsl_spec; rewrite int64_bitmask_modulo.
 Qed.
 
@@ -937,9 +940,12 @@ Lemma uint63_lsr_i64_shr : forall x y,
     (to_Z y < to_Z 63)%Z -> Int64.ishr_u (to_Z x) (to_Z y) = to_Z (x >> y).
 Proof.
   intros.
-  unfold Int64.ishr_u. unfold Int64.shru.
-  repeat rewrite uint63_unsigned_id.
-  rewrite Z.shiftr_div_pow2. 2: now assert (0 <= to_Z y < wB)%Z by apply to_Z_bounded.
+  have H' := to_Z_bounded y.
+  unfold Int64.ishr_u, Int64.shru, Int64.wordsize, Integers.Wordsize_64.wordsize.
+  replace (to_Z 63) with 63%Z in H by now cbn.
+  do 2 rewrite uint63_unsigned_id.
+  replace (Int64.unsigned (Z_to_i64 (to_Z y mod 64%nat))) with (to_Z y). 2: now rewrite Z.mod_small; [rewrite uint63_unsigned_id|].
+  rewrite Z.shiftr_div_pow2. 2: lia.
   now rewrite lsr_spec.
 Qed.
 

--- a/theories/CodegenWasm/LambdaANF_to_Wasm_primitives.v
+++ b/theories/CodegenWasm/LambdaANF_to_Wasm_primitives.v
@@ -815,6 +815,15 @@ Lemma uint63_nlt_int64_nlt :
   forall x y, ~ (to_Z x < to_Z y)%Z -> Int64.ltu (to_Z x) (to_Z y) = false.
 Proof. intros; unfold Int64.ltu; do 2 rewrite uint63_unsigned_id; now rewrite zlt_false. Qed.
 
+Lemma uint63_le_int64_le :
+  forall x y, (to_Z x < to_Z y)%Z -> Int64.ltu (to_Z x) (to_Z y) = true.
+Proof. intros; unfold Int64.ltu; repeat rewrite uint63_unsigned_id; now rewrite zlt_true. Qed.
+
+Lemma uint63_nle_int64_nle :
+  forall x y, ~ (to_Z x < to_Z y)%Z -> Int64.ltu (to_Z x) (to_Z y) = false.
+Proof. intros; unfold Int64.ltu; do 2 rewrite uint63_unsigned_id; now rewrite zlt_false. Qed.
+
+
 Local Ltac solve_arith_op d1 d2 spec :=
   intros; unfold d1, d2; (repeat rewrite uint63_unsigned_id); (try rewrite int64_bitmask_modulo); now rewrite spec.
 
@@ -897,7 +906,7 @@ Proof.
   now apply bit_ext.
 Qed.
 
-Lemma lsl_M_r : forall x y,
+Lemma uint63_lsl63 : forall x y,
     (to_Z 63 <= to_Z y)%Z ->
     to_Z (x << y) = to_Z 0.
 Proof.
@@ -913,6 +922,25 @@ Proof.
   repeat rewrite uint63_unsigned_id.
   rewrite Z.shiftl_mul_pow2. 2: now assert (0 <= to_Z y < wB)%Z by apply to_Z_bounded.
   now rewrite lsl_spec; rewrite int64_bitmask_modulo.
+Qed.
+
+Lemma uint63_lsr63 : forall x y,
+    (to_Z 63 <= to_Z y)%Z ->
+    to_Z (x >> y) = to_Z 0.
+Proof.
+  intros;
+  rewrite (reflect_iff _ _ (lebP 63 y)) in H;
+  now replace (x >> y)%uint63 with 0%uint63; [reflexivity|rewrite lsr_M_r].
+Qed.
+
+Lemma uint63_lsr_i64_shr : forall x y,
+    (to_Z y < to_Z 63)%Z -> Int64.ishr_u (to_Z x) (to_Z y) = to_Z (x >> y).
+Proof.
+  intros.
+  unfold Int64.ishr_u. unfold Int64.shru.
+  repeat rewrite uint63_unsigned_id.
+  rewrite Z.shiftr_div_pow2. 2: now assert (0 <= to_Z y < wB)%Z by apply to_Z_bounded.
+  now rewrite lsr_spec.
 Qed.
 
 End CORRECTNESS.


### PR DESCRIPTION
Prove correctness of left/ right shift operators + update WasmCert to version that fixes semantics of Wasm shifts.

**TODO**: Potentially refactor to reduce code duplication, although this may be postponed for the inevitable bigger clean up up of the proof code for all of the primitive operations.